### PR TITLE
Change the maximum compatability version from 1.12.* to 1.13.*  in the developertools add-on.  The pr...

### DIFF
--- a/developertools/install.rdf
+++ b/developertools/install.rdf
@@ -25,7 +25,7 @@
       <Description>
         <em:id>songbird@songbirdnest.com</em:id>
         <em:minVersion>1.8.0a</em:minVersion>
-        <em:maxVersion>1.12.*</em:maxVersion>
+        <em:maxVersion>1.13.*</em:maxVersion>
       </Description>
     </em:targetApplication>
 
@@ -34,7 +34,7 @@
       <Description>
         <em:id>nightingale@getnightingale.com</em:id>
         <em:minVersion>1.9.0a</em:minVersion>
-        <em:maxVersion>1.12.*</em:maxVersion>
+        <em:maxVersion>1.13.*</em:maxVersion>
       </Description>
     </em:targetApplication>    
 


### PR DESCRIPTION
...evious value caused the add-on not to install on the latest build Version: Nightingale 1.13a, Build 0 (20150104224802)
